### PR TITLE
missing telephone number fix

### DIFF
--- a/src/extractors.js
+++ b/src/extractors.js
@@ -54,12 +54,20 @@ const yelpBusinessPartial = ($) => {
     const domain = get(payload, ['bizDetailsPageProps', 'bizContactInfoProps', 'businessWebsite', 'linkText'], '');
     const website = domain ? `http://${domain}` : '';
     const directUrl = get(payload, 'staticUrl', '');
+    
+    //phone number could be in another json..
+    let otherPhone = null;
+    try
+    {
+        otherPhone = JSON.parse(`{${html.match(/"telephone":".+?"/)[0]}}`).telephone;
+    }
+    catch { };
 
     return {
         bizId: [...bizId.values()][0],
         name: get(payload, ['bizDetailsPageProps', 'businessName'], ''),
         since: get(payload, ['bizDetailsPageProps', 'ratingDetailsProps', 'yearJoined'], ''),
-        phone: get(payload, ['bizDetailsPageProps', 'bizContactInfoProps', 'phoneNumber'], null),
+        phone: get(payload, ['bizDetailsPageProps', 'bizContactInfoProps', 'phoneNumber'], otherPhone),
         website,
         images: [],
         directUrl,


### PR DESCRIPTION
quick fix for https://github.com/yin/apify-yelp/issues/21
takes phone number from another location on the page and put it to the result if there would be null