### PR TITLE
Add option to scrape non-english reviews

### DIFF
--- a/INPUT_SCHEMA.json
+++ b/INPUT_SCHEMA.json
@@ -64,6 +64,12 @@
             "description": "Extract Reviewer name",
             "default": false
         },
+        "includeNonEnglishReviews": {
+            "title": "Include non-English reviews",
+            "type": "boolean",
+            "description": "Include non-English reviews",
+            "default": false
+        },
         "scrapeReviewerUrl": {
             "title": "Reviewer URL",
             "type": "boolean",

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ When using the scraper on the Apify platform or locally, there are multiple conf
 | reviewLimit | number | No | 20 | Minimum number of reviews to scrape. |
 | proxy | proxy configuration | Yes | `{ useApifyProxy: true }` | Proxy groups and other proxy related configuration. |
 | maxRequestRetries | number | No | 10 | How many times a failed request is retried before thrown away. Requests usually failed when blocked by the target site.
+| includeNonEnglishReviews | boolean | No | `false` | By default the scraper will only get reviews in English. You can get reviews in all languages by using this field.
 
 One of `searchTerm` or `directUrls` is required. If none are specified, nothing will be scrapped.
 

--- a/src/extractors.js
+++ b/src/extractors.js
@@ -151,10 +151,15 @@ const yelpBusinessReviews = ({ url, json, scrapeReviewerName, scrapeReviewerUrl 
     return [...reviews.values()];
 };
 
+const yelpReviewLanguages = (json) => {
+    return get(json, 'reviewLanguages', [{ code: 'en' }]).map((lng) => lng.code);
+};
+
 module.exports = {
     yelpSearchResultUrls,
     yelpBusinessPartial,
     yelpBusinessInfo,
     yelpBusinessReviews,
+    yelpReviewLanguages,
     yelpBizPhotos,
 };

--- a/src/main.js
+++ b/src/main.js
@@ -22,6 +22,7 @@ Apify.main(async () => {
         proxy,
         scrapeReviewerName = false,
         scrapeReviewerUrl = false,
+        includeNonEnglishReviews = false,
     } = input;
 
     const proxyConfiguration = await proxyConfigurationValidated({ proxyConfig: proxy });
@@ -59,6 +60,7 @@ Apify.main(async () => {
         failedDataset,
         scrapeReviewerName,
         scrapeReviewerUrl,
+        includeNonEnglishReviews,
     });
     const crawler = new Apify.CheerioCrawler({
         requestQueue,

--- a/src/request-factory.js
+++ b/src/request-factory.js
@@ -114,9 +114,24 @@ const yelpGraphQl = (url, payload) => {
     };
 };
 
-const yelpBusinessReview = (bizId, reviewPageStart = undefined, payload = null) => {
+const yelpBusinessReviewLanguages = (bizId, payload = null) => {
     return {
-        url: `${BASE_URL}/biz/${bizId}/review_feed?rl=en&sort_by=relevance_desc${reviewPageStart ? `&start=${reviewPageStart}` : ''}`,
+        url: `${BASE_URL}/biz/${bizId}/review_feed`,
+        headers: {
+            'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
+            'X-Requested-With': 'XMLHttpRequest',
+            'X-Requested-By-React': true,
+        },
+        userData: {
+            label: CATEGORIES.REVIEW_LANGUAGES,
+            payload,
+        },
+    };
+};
+
+const yelpBusinessReview = (bizId, lng, reviewPageStart = undefined, payload = null) => {
+    return {
+        url: `${BASE_URL}/biz/${bizId}/review_feed?rl=${lng}&sort_by=relevance_desc${reviewPageStart ? `&start=${reviewPageStart}` : ''}`,
         headers: {
             'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
             'X-Requested-With': 'XMLHttpRequest',
@@ -126,6 +141,7 @@ const yelpBusinessReview = (bizId, reviewPageStart = undefined, payload = null) 
             label: CATEGORIES.REVIEW,
             payload: {
                 ...payload,
+                lng,
                 reviewPageStart,
             },
         },
@@ -136,6 +152,7 @@ module.exports = {
     yelpSearch,
     yelpSearchTermAndLocation,
     yelpBusinessInfo,
+    yelpBusinessReviewLanguages,
     yelpBusinessReview,
     yelpGraphQl,
     yelpBizPhotos,

--- a/src/scrapers.js
+++ b/src/scrapers.js
@@ -171,7 +171,7 @@ const createYelpPageHandler = ({
                     ...request.userData.payload.business,
                     reviewLanguages: [payload.lng].concat(data?.reviewLanguages || []),
                     scrapeFinishedAt: new Date().toISOString(),
-                    reviews: allReviews.concat(data?.allReviews || []),
+                    reviews: allReviews.concat(data?.reviews || []),
                 };
 
                 const allLanguagesCount = request.userData.payload.languages.length;

--- a/src/urls.js
+++ b/src/urls.js
@@ -20,6 +20,7 @@ const CATEGORIES = {
     PHOTOS: 'photos',
     GRAPHQL: 'graphql',
     REVIEW: 'review',
+    REVIEW_LANGUAGES: 'review_languages',
     UNKNOWN: 'unknown',
 };
 


### PR DESCRIPTION
Currently, the scraper only gets reviews in English due to the `rl=en` query param being hardcoded.

In my case, I need ALL reviews, no matter the language. Example: https://www.yelp.de/biz/cuccuma-berlin has 94 reviews but only 36 are in English.

To achieve this, I added a new step in the scraping process called `REVIEW_LANGUAGES`. This fetches the URL https://www.yelp.com/biz/j1KMoWRKHnDTqKBEVM45bw/review_feed. Here in the JSON Yelp provides a histogram of the review distribution by languages.

![изображение](https://user-images.githubusercontent.com/17569192/210092439-b8dd0b89-55ee-43eb-b37f-1450cd7702ac.png)

Then I call the `REVIEW` step with the `rl=` param set to every language in the map.

One thing that had to change was the way we push to the main dataset - instead of pushing an item for every language, we use a temporary KV called `OUTPUT`, which gets pushed to the result only when all languages are processed.

This change should bring NO change in behavior if the new input field is `false`, the default. Then the `REVIEW_LANGUAGES` step is skipped, and the scraper works the same way as now.